### PR TITLE
fix: `svelte` entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/arzidava/svelte-media-store.git"
   },
-  "main": "index.svelte.js",
+  "svelte": "index.svelte.js",
   "author": "Stephane Vanraes",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
I figured I'd remove `main` since it won't work outside of svelte anyways.